### PR TITLE
fix strict with set_space_around_op

### DIFF
--- a/R/style-guides-mlr.R
+++ b/R/style-guides-mlr.R
@@ -60,11 +60,9 @@ mlr_style <- function(scope = "tokens",
       style_space_around_tilde = partial(
         style_space_around_tilde, strict = strict
       ),
-      spacing_around_op = if (strict) {
-        set_space_around_op
-      }else {
-        add_space_around_op
-      },
+      spacing_around_op = purrr::partial(
+        set_space_around_op, strict = strict
+      ),
       spacing_around_comma = if (strict) {
         #set_space_after_comma
         add_space_after_comma


### PR DESCRIPTION
Reference: https://github.com/mlr-org/mlr/pull/2498#issuecomment-524013940.

Fix was needed because a function gained a strict argument. Also, note that now, alignment is detected (function calls only). For example: 

``` r
library(styler)
style_text(
  "call(
    a  = 1,   f(x),
    b  = 3, fff(x)
  )",
  style = mlr_style
)
#> call(
#>   a  = 1,   f(x),
#>   b  = 3, fff(x)
#> )
```

<sup>Created on 2019-08-22 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

See https://styler.r-lib.org/articles/detect-alignment.html for details on when styler detects things as *aligned* and the discussion for developing alignment detection in https://github.com/r-lib/styler/issues/258.